### PR TITLE
Add native golang func support for listContent function and remove de…

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -1,8 +1,7 @@
 package input_autocomplete
 
 import (
-	"os/exec"
-	"strings"
+	"io/ioutil"
 )
 
 type CmdUnix struct{}
@@ -14,13 +13,19 @@ type DirLister interface {
 }
 
 func (c CmdUnix) ListContent(path string) ([]string, error) {
-	cmd := exec.Command("ls", "-A", path)
-	stdout, err := cmd.Output()
+	return readDir(path)
+}
+
+// readDir reads the directory named by root and
+// returns a list of directory entries sorted by filename.
+func readDir(root string) ([]string, error) {
+	var files []string
+	fileInfo, err := ioutil.ReadDir(root)
 	if err != nil {
-		return nil, err
+		return files, err
 	}
-
-	lsOutput := strings.Split(string(stdout), "\n")
-
-	return lsOutput, nil
+	for _, file := range fileInfo {
+		files = append(files, file.Name())
+	}
+	return files, nil
 }


### PR DESCRIPTION
Hi @JoaoDanielRufino ,
This PR removes the dependency from ls command which is used in ListContent func.
Instead, it uses native readdir function supported by go.
All test cases are passing.
Please review and let me know if any more changes needs to be done.
Fixes #8 
Br.