### PR TITLE
add ctrl+c support to end the binary execution

### DIFF
--- a/input_autocomplete.go
+++ b/input_autocomplete.go
@@ -2,6 +2,7 @@ package input_autocomplete
 
 import (
 	"fmt"
+
 	"github.com/eiannone/keyboard"
 )
 
@@ -26,7 +27,9 @@ func keyboardListener(input *Input) error {
 			input.RemoveChar()
 		case keyboard.KeyTab:
 			input.Autocomplete()
-
+		case keyboard.KeyCtrlC:
+			fmt.Println("")
+			return nil
 		default:
 			input.AddChar(char)
 		}


### PR DESCRIPTION
Hi @JoaoDanielRufino 
This PR adds support for ctrl+c operation for running binary.
When user types ctrl+c , binary execution should gracefully terminate.
Resolves #8 
Br.