### PR TITLE
add makefile support to build and test the package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY:all
+all: clean test build
+
+.PHONY:build
+build: go-fmt go-vet
+	@echo "building the autocomplete executable"
+	@echo "gopath being used is ${GOPATH}"
+	@echo "goroot being used is ${GOROOT}"
+	go build -x -v -o gia cmd/main.go
+	@echo "executable created gia"
+
+.PHONY:test
+test:
+	@echo "testing the autocomplete package"
+	go test -cover -v -timeout 60s -coverprofile=coverage.out ./...
+	# go cover works well when package is cloned in $GOPATH/src/ directory
+	go tool cover -func=coverage.out
+	go tool cover -html=coverage.out -o coverage.html
+
+.PHONY:clean
+clean:
+	@echo "cleaning the autocomplete package"
+	rm -f gia coverage.out coverage.html
+
+.PHONY:go-fmt
+go-fmt:
+	@echo "formatting the go files using gofmt"
+	gofmt -l -w  .
+
+.PHONY:go-vet
+go-vet:
+	@echo "go vet of the package"
+	go vet -v ./...


### PR DESCRIPTION
HI @JoaoDanielRufino 
This PR adds the support of makefile to build and test the project
As a part of this following functionality is added:
1 makefile support to build the binary. binary is created with name "gia" short of "go-input-autocomplete"
2 go test, coverage report using makefile
3 go fmt and go vet support using makefile to format and vet the go files.
4. cleaning out build/test artifacts using makefile

Please review and let me know if this is what was expected.

Fixes #16 
Br.