### PR TITLE
Implement TAB cycle and update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.dll
 *.so
 *.dylib
+gia
 
 # Test binary, built with `go test -c`
 *.test

--- a/autocomplete.go
+++ b/autocomplete.go
@@ -53,27 +53,7 @@ func (a autocomplete) unixAutocomplete(path string) []string {
 		}
 	}
 
-	contents, err := a.cmd.ListContent(path[:lastSlash+1])
-	if err != nil {
-		return []string{path}
-	}
-
-	var matches []string
-	for _, content := range contents {
-		if hasInsensitivePrefix(content, path[lastSlash+1:]) {
-			p := path[:lastSlash+1] + content
-			ok, err := a.cmd.IsDir(p)
-			if ok && err == nil {
-				p = p + "/"
-			}
-			matches = append(matches, p)
-		}
-	}
-	if len(matches) == 0 {
-		matches = append(matches, path)
-	}
-
-	return matches
+	return a.findFromPrefix(path, lastSlash, "/")
 }
 
 func (a autocomplete) windowsAutocomplete(path string) []string {
@@ -91,21 +71,28 @@ func (a autocomplete) windowsAutocomplete(path string) []string {
 		}
 	}
 
-	contents, err := a.cmd.ListContent(path[:lastSlash+1])
+	return a.findFromPrefix(path, lastSlash, "\\")
+}
+
+func (a autocomplete) findFromPrefix(prefix string, lastSlash int, sep string) []string {
+	contents, err := a.cmd.ListContent(prefix[:lastSlash+1])
 	if err != nil {
-		return []string{path}
+		return []string{prefix}
 	}
 
 	var matches []string
 	for _, content := range contents {
-		if hasInsensitivePrefix(content, path[lastSlash+1:]) {
-			p := path[:lastSlash+1] + content
+		if hasInsensitivePrefix(content, prefix[lastSlash+1:]) {
+			p := prefix[:lastSlash+1] + content
 			ok, err := a.cmd.IsDir(p)
 			if ok && err == nil {
-				p = p + "\\"
+				p = p + sep
 			}
 			matches = append(matches, p)
 		}
+	}
+	if len(matches) == 0 {
+		matches = append(matches, prefix)
 	}
 
 	return matches

--- a/autocomplete_test.go
+++ b/autocomplete_test.go
@@ -2,6 +2,7 @@ package input_autocomplete
 
 import (
 	"errors"
+	"reflect"
 	"runtime"
 	"testing"
 )
@@ -33,7 +34,7 @@ func Test_autocomplete_unixAutocomplete(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   string
+		want   []string
 	}{
 		{
 			name: "success to find some dir or file to autocomplete",
@@ -50,7 +51,7 @@ func Test_autocomplete_unixAutocomplete(t *testing.T) {
 			args: args{
 				path: "ho",
 			},
-			want: "./home",
+			want: []string{"./home"},
 		},
 		{
 			name: "success to find some dir to autocomplete with absolute path",
@@ -67,7 +68,7 @@ func Test_autocomplete_unixAutocomplete(t *testing.T) {
 			args: args{
 				path: "/ho",
 			},
-			want: "/home/",
+			want: []string{"/home/"},
 		},
 		{
 			name: "failed to find some dir or file to autocomplete",
@@ -84,7 +85,7 @@ func Test_autocomplete_unixAutocomplete(t *testing.T) {
 			args: args{
 				path: "auto",
 			},
-			want: "./auto",
+			want: []string{"./auto"},
 		},
 		{
 			name: "failed to find some dir or file to autocomplete",
@@ -101,7 +102,7 @@ func Test_autocomplete_unixAutocomplete(t *testing.T) {
 			args: args{
 				path: "/aut",
 			},
-			want: "/aut",
+			want: []string{"/aut"},
 		},
 		{
 			name: "success to find some dir or file to autocomplete",
@@ -118,7 +119,24 @@ func Test_autocomplete_unixAutocomplete(t *testing.T) {
 			args: args{
 				path: "/bi",
 			},
-			want: "/binary",
+			want: []string{"/binary"},
+		},
+		{
+			name: "success to find multiple dirs or files to autocomplete",
+			fields: fields{
+				cmd: DirListCheckerCustomMock{
+					listContentMock: func(path string) ([]string, error) {
+						return []string{".", "..", "home", "bin", "binary", "etc"}, nil
+					},
+					isDirMock: func(path string) (bool, error) {
+						return false, nil
+					},
+				},
+			},
+			args: args{
+				path: "/bi",
+			},
+			want: []string{"/bin", "/binary"},
 		},
 		{
 			name: "success with empty path",
@@ -135,7 +153,7 @@ func Test_autocomplete_unixAutocomplete(t *testing.T) {
 			args: args{
 				path: "",
 			},
-			want: "",
+			want: []string{""},
 		},
 		{
 			name: "success with already completed path",
@@ -152,7 +170,7 @@ func Test_autocomplete_unixAutocomplete(t *testing.T) {
 			args: args{
 				path: "./file.txt",
 			},
-			want: "./file.txt",
+			want: []string{"./file.txt"},
 		},
 		{
 			name: "failed to list content",
@@ -169,7 +187,7 @@ func Test_autocomplete_unixAutocomplete(t *testing.T) {
 			args: args{
 				path: "/bi",
 			},
-			want: "/bi",
+			want: []string{"/bi"},
 		},
 	}
 	for _, tt := range tests {
@@ -177,7 +195,7 @@ func Test_autocomplete_unixAutocomplete(t *testing.T) {
 			a := autocomplete{
 				cmd: tt.fields.cmd,
 			}
-			if got := a.unixAutocomplete(tt.args.path); got != tt.want {
+			if got := a.unixAutocomplete(tt.args.path); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("unixAutocomplete() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cmd.go
+++ b/cmd.go
@@ -1,7 +1,6 @@
 package input_autocomplete
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -22,7 +21,7 @@ type DirListChecker interface {
 
 func (c Cmd) ListContent(path string) ([]string, error) {
 	var files []string
-	fileInfo, err := ioutil.ReadDir(path)
+	fileInfo, err := os.ReadDir(path)
 	if err != nil {
 		return files, err
 	}

--- a/enable_virtual_terminal.go
+++ b/enable_virtual_terminal.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package input_autocomplete
 
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func EnableVirtalTerminalWindows() error {
+func EnableVirtualTerminalWindows() error {
 	var originalMode uint32
 	stdout := windows.Handle(os.Stdout.Fd())
 

--- a/enable_virtual_terminal_exclude.go
+++ b/enable_virtual_terminal_exclude.go
@@ -1,10 +1,10 @@
-// +build !windows
+//go:build !windows
 
 package input_autocomplete
 
 // We make the assumption that on non-Windows OSes support ANSI escape
 // sequences by default.
 
-func EnableVirtalTerminalWindows() error {
+func EnableVirtualTerminalWindows() error {
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/JoaoDanielRufino/go-input-autocomplete
 
-go 1.14
+go 1.21
 
 require (
-	github.com/eiannone/keyboard v0.0.0-20200508000154-caf4b762e807
-	golang.org/x/sys v0.0.0-20200806125547-5acd03effb82
+	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203
+	golang.org/x/sys v0.18.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/eiannone/keyboard v0.0.0-20200508000154-caf4b762e807 h1:jdjd5e68T4R/j4PWxfZqcKY8KtT9oo8IPNVuV4bSXDQ=
-github.com/eiannone/keyboard v0.0.0-20200508000154-caf4b762e807/go.mod h1:Xoiu5VdKMvbRgHuY7+z64lhu/7lvax/22nzASF6GrO8=
-golang.org/x/sys v0.0.0-20200806125547-5acd03effb82 h1:6cBnXxYO+CiRVrChvCosSv7magqTPbyAgz1M8iOv5wM=
-golang.org/x/sys v0.0.0-20200806125547-5acd03effb82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 h1:XBBHcIb256gUJtLmY22n99HaZTz+r2Z51xUPi01m3wg=
+github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203/go.mod h1:E1jcSv8FaEny+OP/5k9UxZVw9YFWGj7eI4KR/iOBqCg=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/input.go
+++ b/input.go
@@ -60,10 +60,12 @@ func (i *Input) RemoveChar() {
 }
 
 func (i *Input) MoveCursorLeft() {
+	i.isCycling = false
 	i.cursor.MoveLeft()
 }
 
 func (i *Input) MoveCursorRight() {
+	i.isCycling = false
 	if i.cursor.GetPosition() < len(i.currentText) {
 		i.cursor.MoveRight()
 	}

--- a/input_autocomplete.go
+++ b/input_autocomplete.go
@@ -48,7 +48,7 @@ func Read(text string) (string, error) {
 
 	os := runtime.GOOS
 	if os == "windows" {
-		if err := EnableVirtalTerminalWindows(); err != nil {
+		if err := EnableVirtualTerminalWindows(); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
Implement TAB cycle similar to Windows cmd e.g. with files **test1 test2**, typing **test** and hitting TAB will cycle through **test1** and **test2** resolving https://github.com/JoaoDanielRufino/go-input-autocomplete/issues/34.

It's a breaking change - in case there are multiple directories matched with autocomplete, it won't go a level down unless you click right/left arrow or start typing.

Also updated Go and dependencies.